### PR TITLE
remove jquery dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-page-object",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-beta.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -19254,7 +19254,8 @@
     "jquery": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
-      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
+      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==",
+      "dev": true
     },
     "js-string-escape": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "ember-auto-import": "^2.4.0",
     "ember-cli-babel": "^7.24.0",
     "ember-cli-typescript": "^4.1.0",
-    "jquery": "^3.4.1",
     "rsvp": "^4.7.0"
   },
   "devDependencies": {


### PR DESCRIPTION
ember-cli-page-object v2.0.0-beta.3 seems to be bringing in an extra copy of jquery, set as the global version of jquery, interfering with use of jquery plugins with the version of jquery returned by `import $ from jquery`.